### PR TITLE
Fix auth screen still in navigation stack after successfully signing up

### DIFF
--- a/app/src/main/java/com/it235/nureserved/ui/screens/authscreenui/signup/EmailPasswordFieldsScreen.kt
+++ b/app/src/main/java/com/it235/nureserved/ui/screens/authscreenui/signup/EmailPasswordFieldsScreen.kt
@@ -501,7 +501,9 @@ private fun RegisterButton(
                                     .set(userData)
                                     .addOnCompleteListener {e ->
                                         if(e.isSuccessful){
-                                            navController.navigate(ScreenRoutes.Home.route)
+                                            navController.navigate(ScreenRoutes.Home.route) {
+                                                popUpTo(ScreenRoutes.Login.route) { inclusive = true }
+                                            }
                                         }
                                         else{
                                             loading.value = false


### PR DESCRIPTION
Resolves #110 